### PR TITLE
Update font-weight value to handle all states

### DIFF
--- a/src/themes/corteza-base/nunito.scss
+++ b/src/themes/corteza-base/nunito.scss
@@ -5,7 +5,7 @@
   src:
     url($fonts_dir + 'nunito/nunitosans-bold-webfont.woff2') format('woff2'),
     url($fonts_dir + 'nunito/nunitosans-bold-webfont.woff') format('woff');
-  font-weight: normal;
+  font-weight: 100 900;
   font-style: normal;
 }
 
@@ -14,7 +14,7 @@
   src:
     url($fonts_dir + 'nunito/nunitosans-bolditalic-webfont.woff2') format('woff2'),
     url($fonts_dir + 'nunito/nunitosans-bolditalic-webfont.woff') format('woff');
-  font-weight: normal;
+  font-weight: 100 900;
   font-style: normal;
 }
 
@@ -23,7 +23,7 @@
   src:
     url($fonts_dir + 'nunito/nunitosans-semibold-webfont.woff2') format('woff2'),
     url($fonts_dir + 'nunito/nunitosans-semibold-webfont.woff') format('woff');
-  font-weight: normal;
+  font-weight: 100 900;
   font-style: normal;
 }
 
@@ -32,7 +32,7 @@
   src:
     url($fonts_dir + 'nunito/nunitosans-semibolditalic-webfont.woff2') format('woff2'),
     url($fonts_dir + 'nunito/nunitosans-semibolditalic-webfont.woff') format('woff');
-  font-weight: normal;
+  font-weight: 100 900;
   font-style: normal;
 }
 
@@ -41,7 +41,7 @@
   src:
     url($fonts_dir + 'nunito/nunitosans-light-webfont.woff2') format('woff2'),
     url($fonts_dir + 'nunito/nunitosans-light-webfont.woff') format('woff');
-  font-weight: normal;
+  font-weight: 100 900;
   font-style: normal;
 }
 
@@ -50,7 +50,7 @@
   src:
     url($fonts_dir + 'nunito/nunitosans-lightitalic-webfont.woff2') format('woff2'),
     url($fonts_dir + 'nunito/nunitosans-lightitalic-webfont.woff') format('woff');
-  font-weight: normal;
+  font-weight: 100 900;
   font-style: normal;
 }
 
@@ -59,7 +59,7 @@
   src:
     url($fonts_dir + 'nunito/nunitosans-italic-webfont.woff2') format('woff2'),
     url($fonts_dir + 'nunito/nunitosans-italic-webfont.woff') format('woff');
-  font-weight: normal;
+  font-weight: 100 900;
   font-style: normal;
 }
 
@@ -68,6 +68,6 @@
   src:
     url($fonts_dir + 'nunito/nunitosans-regular-webfont.woff2') format('woff2'),
     url($fonts_dir + 'nunito/nunitosans-regular-webfont.woff') format('woff');
-  font-weight: normal;
+  font-weight: 100 900;
   font-style: normal;
 }


### PR DESCRIPTION
Updating the `normal` value to `100 900` range value which allow more browsers to use them correctly as every "font-face" has a dedicated "font-family" name.