### PR TITLE
Properly show error caused by internal workflow errors

### DIFF
--- a/src/components/WorkflowEditor.vue
+++ b/src/components/WorkflowEditor.vue
@@ -2006,6 +2006,8 @@ export default {
             } else {
               this.raiseSuccessAlert(this.$t('notification:workflow-test-completed'), this.$t('notification:test-completed'))
             }
+          } else if (error) {
+            throw new Error(error)
           } else {
             this.raiseWarningAlert(this.$t('notification:trace-unavailable'), this.$t('notification:test-completed'))
           }


### PR DESCRIPTION
When an internal WF error occurred (nil panic exception for me), the error was not shown and was masked as "no trace available".
This is what I found resolved the issue; please suggest something better if this is not ok